### PR TITLE
fix 1105

### DIFF
--- a/modules/game_cyclopedia/tab/items/items.lua
+++ b/modules/game_cyclopedia/tab/items/items.lua
@@ -61,15 +61,6 @@ function showItems()
     controllerCyclopedia.ui.GoldBase:setVisible(false)
     controllerCyclopedia.ui.BestiaryTrackerButton:setVisible(false)
 
-    local lootFilterValue = modules.game_quickloot.quickLootController.ui.filters.add:getText()
-    if string.match(lootFilterValue:lower(), "skipped") then
-        UI.InfoBase.SkipQuickLootCheck:setVisible(true)
-        UI.InfoBase.LootQuickLootCheck:setVisible(false)
-    else
-        UI.InfoBase.SkipQuickLootCheck:setVisible(false)
-        UI.InfoBase.LootQuickLootCheck:setVisible(true)
-    end
-
     local CategoryColor = "#484848"
 
     for _, data in ipairs(Cyclopedia.CategoryItems) do
@@ -267,25 +258,21 @@ function Cyclopedia.internalCreateItem(data)
         end
         widget:setBackgroundColor("#585858")
        
-        UI.InfoBase.SkipQuickLootCheck.onCheckChange = function(self, checked)
-            UI.InfoBase.SkipQuickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), 1))
+        if modules.game_quickloot.QuickLoot.data.filter == 2 then
+            UI.InfoBase.quickLootCheck:setText("Loot when Quick Looting")
+        else
+            UI.InfoBase.quickLootCheck:setText('Skip when Quick Looting')
+        end
+        UI.InfoBase.quickLootCheck.onCheckChange = function(self, checked)
             if checked then
-                modules.game_quickloot.QuickLoot.addLootList(data:getId(), 1)
+                modules.game_quickloot.QuickLoot.addLootList(data:getId(), modules.game_quickloot.QuickLoot.data.filter)
             else
-                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 1)
+                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), modules.game_quickloot.QuickLoot.data.filter)
             end
         end
+        UI.InfoBase.quickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), modules.game_quickloot.QuickLoot.data.filter))
 
-        UI.InfoBase.LootQuickLootCheck.onCheckChange = function(self, checked)
-            UI.InfoBase.LootQuickLootCheck:setChecked(modules.game_quickloot.QuickLoot.lootExists(data:getId(), 2))
-            if checked then
-                modules.game_quickloot.QuickLoot.addLootList(data:getId(), 2)
-            else
-                modules.game_quickloot.QuickLoot.removeLootList(data:getId(), 2)
-            end
-        end
-
-         local buy, sell = Cyclopedia.formatSaleData(internalData:getNpcSaleData())
+        local buy, sell = Cyclopedia.formatSaleData(internalData:getNpcSaleData())
         local sellColor = "#484848"
 
         for index, value in ipairs(sell) do

--- a/modules/game_cyclopedia/tab/items/items.otui
+++ b/modules/game_cyclopedia/tab/items/items.otui
@@ -425,21 +425,17 @@ UIWidget
       !text: tr('Track drops of this item')
       text-auto-resize: true
     CheckBox
-      id: SkipQuickLootCheck
+      id: quickLootCheck
       anchors.right: parent.right
       anchors.bottom: parent.bottom
       margin-bottom: 35
-      !text: tr('Skip when Quick Looting')
-
       text-auto-resize: true
-    CheckBox
-      id: LootQuickLootCheck
-      anchors.right: parent.right
-      anchors.bottom: parent.bottom
-      margin-bottom: 35
-      !text: tr('Loot when Quick Looting')
-
-      text-auto-resize: true
+      @onSetup: |
+        if modules.game_quickloot.QuickLoot.data.filter == 2 then
+          self:setText("Loot when Quick Looting")
+        else
+          self:setText('Skip when Quick Looting')
+        end
 
   Button
     id: ManageButton

--- a/modules/game_quickloot/quickloot.lua
+++ b/modules/game_quickloot/quickloot.lua
@@ -421,6 +421,9 @@ function QuickLoot.Define()
         end
         QuickLoot.show()
         QuickLoot.loadFilterItems()
+        if QuickLoot.data.filter == 2 and not quickLootController.ui.filters.accepted:isChecked() then
+            quickLootController.ui.filters.accepted:onClick()
+        end
     end
 
     function QuickLoot.show()


### PR DESCRIPTION
@bdzicc  

when testing I noticed some unwanted behavior in the checkbox, check the pr I did in your repository, 


I noticed that you use getText to know if you're currently in skipquick or lootquick, with the function `modules.game_quickloot.QuickLoot.data.filter `it's easier to determine.

![image](https://github.com/user-attachments/assets/86ff8d4b-58bb-4a50-9022-28b82c422ac7)

Also, I made an optimization. I found it unnecessary to have two checkboxes stacked on top of each other, so I used a single function. If you look closely in your pr , they are the same.
the only difference is the number, which is `modules.game_quickloot.QuickLoot.data.filter `
![image](https://github.com/user-attachments/assets/6374fbf1-d775-46c8-8f82-7c5f534d7122)

https://github.com/user-attachments/assets/c6055b34-ffa8-4c7a-aa25-2e8d6fa1796c
